### PR TITLE
Support multiple queues, add Prometheus metrics, fix "no such table" error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ before_install:
   - go get -u -ldflags "-s -w" github.com/streadway/amqp
   - go get -u -ldflags "-s -w" github.com/mattn/go-sqlite3
   - go get -u -ldflags "-s -w" k8s.io/client-go/...
+  - go get -u -ldflags "-s -w" github.com/prometheus/client_golang/prometheus
+  - go get -u -ldflags "-s -w" github.com/prometheus/client_golang/prometheus/promhttp
   - mkdir -p $HOME/gopath/src/k8s.io && git clone --depth 1 -b v1.9.3 --single-branch -q https://github.com/kubernetes/kubernetes.git $HOME/gopath/src/k8s.io/kubernetes
 
 script:

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,8 @@ depend:
 	go get -u -ldflags "-s -w" github.com/streadway/amqp
 	go get -u -ldflags "-s -w" github.com/mattn/go-sqlite3
 	go get -u -ldflags "-s -w" k8s.io/client-go/...
+	go get -u -ldflags "-s -w" github.com/prometheus/client_golang/prometheus
+	go get -u -ldflags "-s -w" github.com/prometheus/client_golang/prometheus/promhttp
 	if [ -d $(GOPATH)/src/k8s.io/kubernetes ] ; then rm -rf $(GOPATH)/src/k8s.io/kubernetes ; fi && git clone --depth 1 -b v1.9.3 --single-branch -q https://github.com/kubernetes/kubernetes.git $(GOPATH)/src/k8s.io/kubernetes
 
 

--- a/kube.go
+++ b/kube.go
@@ -14,6 +14,7 @@ import (
 	restclient "k8s.io/client-go/rest"
 	certutil "k8s.io/client-go/util/cert"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -22,6 +23,17 @@ const (
 	jobKind                   = "Job"
 	replicationControllerKind = "ReplicationController"
 	replicaSetKind            = "ReplicaSet"
+)
+
+var (
+	scalingEvents = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "scaling_events_total",
+			Help:      "Count of scaling events by resource kind.",
+		},
+		[]string{"kind", "name"},
+	)
 )
 
 type apiContext struct {
@@ -62,6 +74,7 @@ func scaleDeployments(c *kubernetes.Clientset, ns string, name string, newSize i
 	replicas := b.newSize(*deployment.Spec.Replicas, newSize)
 	if replicas != *deployment.Spec.Replicas {
 		log.Printf("Scaling deployment '%s' from %d to %d replicas", name, deployment.Spec.Replicas, replicas)
+		scalingEvents.With(prometheus.Labels{"kind": "Deployment", "name": name}).Inc()
 		deployment.Spec.Replicas = &replicas
 		_, err = c.AppsV1beta2().Deployments(ns).Update(deployment)
 		if err != nil {
@@ -79,6 +92,7 @@ func scaleReplicaSets(c *kubernetes.Clientset, ns string, name string, newSize i
 	replicas := b.newSize(*pod.Spec.Replicas, newSize)
 	if replicas != *pod.Spec.Replicas {
 		log.Printf("Scaling replica set '%s' from %d to %d replicas", name, pod.Spec.Replicas, replicas)
+		scalingEvents.With(prometheus.Labels{"kind": "ReplicaSet", "name": name}).Inc()
 		pod.Spec.Replicas = &replicas
 		_, err = c.AppsV1beta2().ReplicaSets(ns).Update(pod)
 		if err != nil {

--- a/kube.go
+++ b/kube.go
@@ -56,6 +56,9 @@ func scaleKind(c *kubernetes.Clientset, kind string, ns string, name string, new
 
 func scaleDeployments(c *kubernetes.Clientset, ns string, name string, newSize int32, b *scaleBounds) error {
 	deployment, err := c.AppsV1beta2().Deployments(ns).Get(name, v1.GetOptions{})
+	if err != nil {
+		return err
+	}
 	replicas := b.newSize(*deployment.Spec.Replicas, newSize)
 	if replicas != *deployment.Spec.Replicas {
 		log.Printf("Scaling deployment '%s' from %d to %d replicas", name, deployment.Spec.Replicas, replicas)

--- a/main.go
+++ b/main.go
@@ -36,7 +36,7 @@ func init() {
 	flag.IntVar(&statsIntervalParam, "stats-interval", 5, "time interval between metrics gathering runs in seconds")
 	flag.IntVar(&evalIntervalsParam, "eval-intervals", 2, "number of autoscale intervals used to calculate average queue length")
 	flag.Float64Var(&statsCoverageParam, "stats-coverage", 0.75, "required percentage of statistics to calculate average queue length")
-	flag.StringVar(&dbFileParam, "db", ":memory:", "sqlite3 database filename")
+	flag.StringVar(&dbFileParam, "db", "file::memory:?cache=shared", "sqlite3 database filename")
 	flag.StringVar(&dbDirParam, "db-dir", "", "directory for sqlite3 statistics database file")
 
 	flag.BoolVar(&version, "version", false, "show version")


### PR DESCRIPTION
I've added a few enhancements here that I thought would be worth kicking
back upstream.

First is to add some error checking that just kicks back a more
descriptive error when we fail to get a deply.

Next was a little race condition involving multiple Go threads and
SQLite. Fixable without code, but I thought we could have a better
default here.

Last commit was adding support for multiple queues. It just sums over a
comma-separated list. I also added Prometheus metrics while doing this,
it ought to be a separate commit, but if you're interested in one, and
not the other, I could split them up.

Thanks for the great project!