### PR TITLE
Autoescaler is always scaling less than expected

### DIFF
--- a/actuator.go
+++ b/actuator.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log"
 	"time"
+	"math"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -81,7 +82,7 @@ func (ctx *scaleContext) newSize(avg float64, cov float64) (int32, error) {
 	if cov < ctx.Coverage {
 		err = fmt.Errorf("not enough metrics to calculate new size, required at least %.2f was %.2f metrics ratio", ctx.Coverage, cov)
 	} else {
-		replicas = int32(avg / float64(ctx.Threshold))
+		replicas = int32(math.Ceil(avg / float64(ctx.Threshold)))
 	}
 	return replicas, err
 }

--- a/actuator_test.go
+++ b/actuator_test.go
@@ -27,7 +27,7 @@ func TestNewSize(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got, want := s, int32(2); got != want {
+	if got, want := s, int32(3); got != want {
 		t.Errorf("Expected %d, got: %d", want, got)
 	}
 }


### PR DESCRIPTION
Currently if you set the `min` pods to 0 and you stablishes any `threshold`, when you go bellow the threshold, the autoscaler sets the Kubernetes resource to autoscale (`name`) to 0, so they will never consume the messages.

The expected behaviour is to every threshold chunk of messages, to have a consumer. 

For example:
```
Thershold: 100
Min pods: 0
Current messages: 50
Expected pods: 1
```

```
Thershold: 100
Min pods: 0
Current messages: 150
Expected pods: 2
```

```
Thershold: 100
Min pods: 0
Current messages: 0
Expected pods: 0
```

This behaviour represents the documentation in the README
`threshold required, number of messages on a queue representing maximum load on the autoscaled Kubernetes resource`

So one pod can't afford more than that threshold.